### PR TITLE
Enable finding element or elements by type array

### DIFF
--- a/uiauto/lib/element-patch/lookup-patch.js
+++ b/uiauto/lib/element-patch/lookup-patch.js
@@ -2,6 +2,49 @@
 
 (function () {
 
+  // return all elements of type contained in typeArray
+  UIAElement.prototype._elementOrElementsByType = function (typeArray, onlyFirst, onlyVisible) {
+    if (!typeArray) throw new Error("Must provide typeArray when calling _elementOrElementsByType");
+    var numTypes = typeArray.length;
+    onlyFirst = onlyFirst === true;
+    onlyVisible = onlyVisible !== false;
+
+    var target = $.target();
+    target.pushTimeout(0);
+
+    var getTree = function (element) {
+      var elems = [];
+      // process element
+      var visible = element.isVisible() === 1;
+      var elType = element.type();
+      for (var i = 0; i < numTypes; i++) {
+        if (elType === typeArray[i]) {
+          if (!onlyVisible || visible) {
+            elems.push(element);
+            if (onlyFirst && elems.length === 1) return elems;
+            break;
+          }
+        }
+      }
+
+      if (element.hasChildren()) {
+        var children = element.elements();
+        var numChildren = children.length;
+        for (var i = 0; i < numChildren; i++) {
+          if (onlyFirst && elems.length === 1) return elems;
+          elems = elems.concat(getTree(children[i]));
+        }
+      }
+
+      return elems;
+    };
+
+    var foundElements = getTree(this);
+    target.popTimeout();
+
+    return $.smartWrap(foundElements).dedup();
+  };
+
   UIAElement.prototype.getFirstWithPredicateWeighted = function (predicate) {
     var weighting = [
         'secureTextFields'


### PR DESCRIPTION
It'd be great if @sebv could review this. I verified it works on UICatalog.

My goal is to filter elements by type array, visibility, and only first. Then I can use predicate selectors on the element list and avoid using xpath.
## 

> Add _elementOrElementsByType
> 
> Usage Example:
> 
>  find_element :uiautomation, %Q($.mainWindow()._elementOrElementsByType(["UIAStaticText"], true, true))
> find_elements :uiautomation, %Q($.mainWindow()._elementOrElementsByType(["UIAStaticText"], false, true))

Fix #32
