### PR TITLE
Fix UIAElement.setValueByType

### DIFF
--- a/uiauto/lib/element-patch/helper-patch.js
+++ b/uiauto/lib/element-patch/helper-patch.js
@@ -14,7 +14,23 @@
       if (isAccented(newValue)) {
         this.setValue(newValue);
       } else {
-        $.sendKeysToActiveElement(newValue);
+        /*
+         * Sending large chunks of text, especially with capital letters,
+         * often muddles the input causing errors where keys are not
+         * found. Breaking into individual letters, while slower, fixes
+         * the problem.
+         */
+        for (i = 0; i < newValue.length; i++) {
+          var c = newValue.charAt(i);
+          try {
+            $.sendKeysToActiveElement(c);
+          } catch (e) {
+            // retry once
+            $.debug("Error typing '" + c + "': " + e);
+            $.debug("Retrying...");
+            $.sendKeysToActiveElement(c);
+          }
+        }
       }
     } else if (type === "UIAPickerWheel") {
       this.selectValue(newValue);


### PR DESCRIPTION
iOS tests sometimes fail with because the typing is too fast and keys get out of sync, particularly when shifted. The solution is to send each key individually, rather than through `sendKeysToActiveElement`. Also, on error, we should retry the key once.
