### PR TITLE
Add configurable delay for typing

### DIFF
--- a/lib/dynamic-bootstrap.js
+++ b/lib/dynamic-bootstrap.js
@@ -17,7 +17,8 @@ function getEnv(opts) {
     nodePath: process.execPath,
     commandProxyClientPath: path.resolve(
       __dirname, '../bin/command-proxy-client.js'),
-    instrumentsSock: opts.sock || '/tmp/instruments_sock'
+    instrumentsSock: opts.sock || '/tmp/instruments_sock',
+    interKeyDelay: opts.interKeyDelay || null
   };
   return bootstrapEnv;
 }

--- a/uiauto/lib/element-patch/helper-patch.js
+++ b/uiauto/lib/element-patch/helper-patch.js
@@ -1,4 +1,4 @@
-/* globals $ */
+/* globals $, env */
 
 (function () {
   UIAElement.prototype.setValueByType = function (newValue) {
@@ -29,6 +29,9 @@
             $.debug("Error typing '" + c + "': " + e);
             $.debug("Retrying...");
             $.sendKeysToActiveElement(c);
+          }
+          if (env.interKeyDelay) {
+            $.delay(env.interKeyDelay);
           }
         }
       }

--- a/uiauto/lib/env.js
+++ b/uiauto/lib/env.js
@@ -7,6 +7,7 @@ var env;
     this.nodePath = dynamicEnv.nodePath;
     this.commandProxyClientPath = dynamicEnv.commandProxyClientPath;
     this.instrumentsSock = dynamicEnv.instrumentsSock;
+    this.interKeyDelay = dynamicEnv.interKeyDelay;
   };
 
 })();


### PR DESCRIPTION
Since `setInterKeyDelay` doesn't seem to work (and it is relying on a private API), this adds a manual delay after each character. Hopefully this slows things down enough. This will translate into an iOS cap for `interKeyDelay`.
