### PR TITLE
Check for UIAElementNil before looking up child elements

### DIFF
--- a/uiauto/lib/element-patch/lookup-patch.js
+++ b/uiauto/lib/element-patch/lookup-patch.js
@@ -145,10 +145,12 @@
     if (!onlyFirst || results.length === 0) {
       var child;
       for (var a = 0, len = this.elements().length; a < len; a++) {
-          child = this.elements()[a];
+        child = this.elements()[a];
+        if (!child.isNil()) {
           results = results.concat(child
                       ._elementOrElementsWithPredicateWeighted(predicate,
                         weighting, onlyFirst, onlyVisible));
+        }
       }
     }
 


### PR DESCRIPTION
In some of my tests, I found that child can actually be a UIAElementNil object. Doing this check fixed the Javascript Error that was getting thrown when I was trying to call _elementOrElementsWithPredicateWeighted on it.
