### PR TITLE
Use both label() and value() methods to get text

### DIFF
--- a/uiauto/lib/element-patch/helper-patch.js
+++ b/uiauto/lib/element-patch/helper-patch.js
@@ -86,12 +86,11 @@
   };
 
   UIAElement.prototype.text = function () {
-    var type = this.type();
-    if (type === "UIAButton") {
-      return this.label();
-    } else {
-      return this.value();
-    }
+    var label = this.label();
+    var value = this.value();
+    
+    if (label) return label;
+    return value;
   };
 
   UIAElement.prototype.matchesTagName = function (tagName) {


### PR DESCRIPTION
Hi,

I see that currently there's a `UIElement` type check before getting actual text : for `UIButton` method `label()` is used, for others - `value()`. But in many cases `label()` method returns visible text for non-button elements too. Please see screenshot.

![2014-08-13_16h38_03](https://cloud.githubusercontent.com/assets/5451824/3906966/af0ce072-22f7-11e4-97f6-26c5b99d1f1b.png)

I suggest to check whether `label()` method returns non-null & non-empty value, if so then return `label()`. In other cases let's return `value()`.
