### PR TITLE
Remove broken element logging

### DIFF
--- a/uiauto/lib/mechanic-ext/xpath-ext.js
+++ b/uiauto/lib/mechanic-ext/xpath-ext.js
@@ -262,9 +262,6 @@
         }
       }
       if (ret === null) {
-        $.each(elems,function (i, elem) {
-          $(elem).log();
-        });
         ret = $.smartWrap(elems).dedup();
       }
       $.target().popTimeout();


### PR DESCRIPTION
`UIAElement.logElement()`/`UIAElement.logElementTree()` (called by [`$(element).log()`](https://github.com/jaykz52/mechanic/blob/master/src/logging.js#L28)) consistently fails with the error

``` shell
Instruments Trace Error : *** -[NSURL URLByAppendingPathComponent:]: component, components, or pathExtension cannot be nil.
```

followed by Instruments crashing. This happens when calling the function multiple times, often but seemingly at random.

The log lines in the xpath extension to Mechanic do not add much to the logs, as the calling function logs the results retrieved. Currently, we get

``` shell
info: [debug] [INST] 2014-09-15 21:26:19 +0000 logElementTree:
       UIAStaticText "© 2013 Josh Long" {{10, 653}, {103, 16}}
2014-09-15 21:26:19 +0000 Debug: evaluation finished
2014-09-15 21:26:19 +0000 Debug: Lookup returned [object UIAStaticText] with the name "© 2013 Josh Long" (id: 0).
```

and with this change we will get

``` shell
info: [debug] [INST] 2014-09-15 21:27:24 +0000 Debug: evaluation finished
info: [debug] [INST] 2014-09-15 21:27:24 +0000 Debug: Lookup returned [object UIAStaticText] with the name "© 2013 Josh Long" (id: 0).
```

This should fix appium/appium#3154.
