### PR TITLE
Add autoAcceptAlerts to dynamic bootstrap env

### DIFF
--- a/lib/dynamic-bootstrap.js
+++ b/lib/dynamic-bootstrap.js
@@ -20,7 +20,8 @@ function getEnv(opts) {
       __dirname, '../bin/command-proxy-client.js'),
     instrumentsSock: opts.sock || '/tmp/instruments_sock',
     interKeyDelay: opts.interKeyDelay || null,
-    justLoopInfinitely: opts.justLoopInfinitely
+    justLoopInfinitely: opts.justLoopInfinitely,
+    autoAcceptAlerts: opts.autoAcceptAlerts
   };
   return bootstrapEnv;
 }

--- a/uiauto/lib/alerts.js
+++ b/uiauto/lib/alerts.js
@@ -1,4 +1,4 @@
-/* global autoAcceptAlerts, $ */
+/* global $, env */
 
 var alerts;
 
@@ -8,7 +8,7 @@ var alerts;
     UIATarget.onAlert = function (alert) {
       if (alert.name() && alert.name().indexOf("attempting to open a pop-up") !== -1 && alert.buttons().length > 0) {
         $.acceptAlert();
-      } else if (autoAcceptAlerts && alert.buttons().length > 0) {
+      } else if (env.autoAcceptAlerts && alert.buttons().length > 0) {
         $.acceptAlert();
       }
       return true;

--- a/uiauto/lib/env.js
+++ b/uiauto/lib/env.js
@@ -9,6 +9,7 @@ var env;
     this.instrumentsSock = dynamicEnv.instrumentsSock;
     this.interKeyDelay = dynamicEnv.interKeyDelay;
     this.justLoopInfinitely = dynamicEnv.justLoopInfinitely;
+    this.autoAcceptAlerts = dynamicEnv.autoAcceptAlerts;
   };
 
 })();


### PR DESCRIPTION
It is known that alerts can be flakey at the beginning of tests. Particularly the location services alert that `autoAcceptAlerts` would handle. This change (and associated change in the server) moves the availability of `autoAcceptAlerts` a little earlier, to catch a few more cases, though admittedly not all.

It also, to my mind, makes sense to put the variable here, as it is part of the environment in the same way as the others, as opposed to configuration parameters.
