### PR TITLE
Fix tap regression

### DIFF
--- a/uiauto/lib/mechanic-ext/keyboard-ext.js
+++ b/uiauto/lib/mechanic-ext/keyboard-ext.js
@@ -68,7 +68,7 @@
       }
     }
 
-    , _swipeToHideKeyboard: function () {
+    , _swipeDownToHideKeyboard: function () {
       $.debug("Hiding keyboard using swipe keyboard");
       var startY = $.mainApp().keyboard().rect().origin.y - 10;
       var endY = $.mainWindow().rect().size.height - 10;
@@ -85,11 +85,13 @@
         case 'pressKey':
           $._pressKeyToHideKeyboard(keyName);
           break;
-        case 'swipe':
+        case 'swipeDown':
+          $._swipeDownToHideKeyboard();
+          break;
         case 'tapOut':
         case 'tapOutside':
         case 'default':
-          $._swipeToHideKeyboard();
+          $($.mainWindow()).tap();
           break;
         default:
           throw new Error('Unknown strategy: ' + strategy);


### PR DESCRIPTION
By removing tap, we caused a regression in the uicatalog/clear-specs tests. The problem with the "tap" strategy isn't that it's not reliable, it's that there are an infinite number of ways to close the keyboard.  It's ultimately up to the developer, so all we can do in hideKeyboard is provide a few of the most common strategies. Tapping on the background is a common strategy, so it should remain in the code.
