### PR TITLE
Fix #3648: improved reliability of keyboard access in ios

### DIFF
--- a/uiauto/lib/mechanic-ext/basics-ext.js
+++ b/uiauto/lib/mechanic-ext/basics-ext.js
@@ -3,15 +3,61 @@
 (function () {
   var delaySec = $.delay;
   $.extend($, {
-    system: function () { return UIATarget.localTarget().host(); }
+
+    system: function () { return $.target().host(); }
+
     , target: function () { return UIATarget.localTarget(); }
-    , mainWindow: function () { return UIATarget.localTarget().frontMostApp().mainWindow(); }
-    , mainApp: function () { return UIATarget.localTarget().frontMostApp(); }
-    , keyboard: function () { return UIATarget.localTarget().frontMostApp().keyboard(); }
-    , bundleId: function ()  { return UIATarget.localTarget().frontMostApp().bundleID(); }
+
+    , mainWindow: function () { return $.mainApp().mainWindow(); }
+
+    , mainApp: function () {
+      var app = null;
+
+      if (!$.tryWaitForCondition(function() {
+        app = $.target().frontMostApp();
+        return app && app.isValid(); })) {
+        throw new Error("No valid frontmost app was found.");
+      }
+
+      return app;
+    }
+
+    , keyboard: function () {
+      var appKeyboard = null;
+
+      if (!$.tryWaitForCondition(function() {
+        appKeyboard = $.mainApp().keyboard();
+        return appKeyboard && appKeyboard.isValid(); })) {
+        throw new Error("Could not locate keyboard.");
+      }
+      
+      return appKeyboard;
+    }
+
+    , bundleId: function () { return $.mainApp().bundleID(); }
+
     // overriding existing delay
     , delay: function (ms) { delaySec.call(this, ms/1000); }
+
     , logTree: function () {$($.mainApp()).logTree();}
+
     , debug: function (s) { if ($.isVerbose) UIALogger.logDebug(s); }
+
+    , tryWaitForCondition: function(condition, interval) {
+      if (typeof condition !== 'function') {
+        throw new Error("Must provide a callback returning a boolean.")
+      }
+
+      var i = interval || 20, t = 0;
+      var isMet = condition();
+
+      while (t < 3000 && !isMet) {
+        t += i;
+        $.delay(i);
+        isMet = condition();
+      }
+
+      return isMet;
+    }
   });
 })();

--- a/uiauto/lib/mechanic-ext/keyboard-ext.js
+++ b/uiauto/lib/mechanic-ext/keyboard-ext.js
@@ -46,17 +46,6 @@
       }
     }
 
-    , _tryWaitKbHidden: function() {
-      var interval = 50, t = 0;
-
-      while(t < 3000 && !$.mainApp().keyboard().isNil()) {
-        t += interval;
-        $.delay(interval);
-      }
-
-      return $.mainApp().keyboard().isNil();
-    }
-
     , _pressKeyToHideKeyboard: function (keyName) {
       $.debug("Hiding keyboard with keyName " + keyName);
       var key = this.keyboard().buttons()[keyName];
@@ -97,7 +86,7 @@
           throw new Error('Unknown strategy: ' + strategy);
       }
 
-      if(!$._tryWaitKbHidden()) {
+      if(!$.tryWaitForCondition(function(){ return $.mainApp().keyboard().isNil(); })) {
         throw new Error("Failed to hide keyboard.");
       }
     }


### PR DESCRIPTION
Add some redundancy to offset Instruments' flaky behavior when locating the foremost app and keyboard.
