### PR TITLE
Fix _elementOrElementsByType matching

### DIFF
--- a/uiauto/lib/element-patch/lookup-patch.js
+++ b/uiauto/lib/element-patch/lookup-patch.js
@@ -13,6 +13,11 @@
     if (!typeArray) throw new Error("Must provide typeArray when calling _elementOrElementsByType");
 
     var numTypes = typeArray.length;
+
+    // allow '*' to match on all types.
+    var allTypes = false;
+    if (numTypes === 1 && typeArray[0] === '*') allTypes = true;
+
     onlyFirst = onlyFirst === true;
     onlyVisible = onlyVisible !== false;
 
@@ -57,7 +62,7 @@
       var visible = element.isVisible() === 1;
       var elType = element.type();
       for (var i = 0; i < numTypes; i++) {
-        if (elType === typeArray[i]) {
+        if (allTypes || elType === typeArray[i]) {
           if (!onlyVisible || visible) {
             // if an object isn't provided then it's a match.
             var nameMatch  = nameObject  ? attributeMatch(element.name(),  nameObject)  : false;


### PR DESCRIPTION
I messed up the matching logic. This PR fixes it. In [ruby_lib](https://github.com/appium/ruby_lib/commit/98a561beae09017eaa8be4b1d7cdaf5e3d6e1575?diff=unified) I want to request a match on name, label, or value instead of `&&`.
