### PR TITLE
Check target element before searching

### DIFF
--- a/uiauto/lib/element-patch/lookup-patch.js
+++ b/uiauto/lib/element-patch/lookup-patch.js
@@ -2,6 +2,14 @@
 
 (function () {
 
+  $._elementOrElementsByType = function (targetElement, opts) {
+     if (!targetElement || targetElement.isNil()) {
+      throw new Error("Target element must exist");
+    }
+
+    return targetElement._elementOrElementsByType(opts);
+  };
+
   UIAElement.prototype._elementOrElementsByType = function (opts) {
     var typeArray   = opts.typeArray,
         onlyFirst   = opts.onlyFirst,


### PR DESCRIPTION
Passing the element as a param allows a nil check.

 execute_script '$._elementOrElementsByType($.mainWindow(), {...})'

Instead of

 execute_script '$.mainWindow()._elementOrElementsByType({...})'