### PR TITLE
Added getWithNameAndTap().

### DIFF
--- a/uiauto/lib/element-patch/lookup-patch.js
+++ b/uiauto/lib/element-patch/lookup-patch.js
@@ -215,4 +215,10 @@
     return this.getAllWithPredicate(_formatPredicate(targetName, true), onlyVisible);
   };
 
+  UIAElement.prototype.getWithNameAndTap = function (targetName, onlyVisible) {
+    el = this.getWithName(targetName, onlyVisible);
+    el.tap();
+    return el;
+  };
+
 })();


### PR DESCRIPTION
A very common use case is to find an element and click on it.
This patch is an enhancement for such case where we can find element and click on it using a single ``getWithNameAndTap`` call. In our testing, this has helped to make tests run faster. 