### PR TITLE
iOS 9.1 fixes: accept/dismiss & delete/backspace

### DIFF
--- a/uiauto/lib/mechanic-ext/alert-ext.js
+++ b/uiauto/lib/mechanic-ext/alert-ext.js
@@ -53,7 +53,9 @@
       if (!alert.isNil()) {
         var acceptButton = alert.defaultButton();
         var buttonCount = alert.buttons().length;
-        if (acceptButton.isNil() && buttonCount > 0) {
+        // iOS9.1 returns 'cancel' as the default button.
+        if ((parseFloat($.systemVersion) >= 9.1 && buttonCount > 0) || 
+            (acceptButton.isNil() && buttonCount > 0)) {
           // last button is accept
           acceptButton = alert.buttons()[buttonCount - 1];
         }

--- a/uiauto/lib/mechanic-ext/basics-ext.js
+++ b/uiauto/lib/mechanic-ext/basics-ext.js
@@ -41,6 +41,8 @@
 
     , bundleId: function () { return $.mainApp().bundleID(); }
 
+    , systemVersion: UIATarget.localTarget().systemVersion()
+    
     // overriding existing delay
     , delay: function (ms) { delaySec.call(this, ms/1000); }
 

--- a/uiauto/lib/mechanic-ext/keyboard-ext.js
+++ b/uiauto/lib/mechanic-ext/keyboard-ext.js
@@ -38,7 +38,11 @@
 
   , typeKey: function (k) {
       if (k === '\uE003' || k === '\ue017') { // BACKSPACE or DELETE
-        $.keyboard().keys().Delete.tap();
+        if (parseFloat($.systemVersion) >= 9.1) {
+          $.keyboard().keys().delete.tap();
+        } else {
+          $.keyboard().keys().Delete.tap();
+        }
       } else if (k === '\uE006' || k === '\uE007') {// RETURN ENTER
         $.keyboard().typeString("\n");
       } else {


### PR DESCRIPTION
There are [reports](https://github.com/appium/appium-uiauto/pull/88) the accept/dismiss issue is also in iOS 9.0. I can't reproduce this from our e2e tests.

@imurchie 