### PR TITLE
Alert fix

### DIFF
--- a/test/uiauto/alert-specs.js
+++ b/test/uiauto/alert-specs.js
@@ -54,7 +54,8 @@ describe('alarm', function () {
           return alertText;
         }
       );
-      res.should.include('A message should be a short, complete sentence');
+      res.should.include('A Short Title Is Best');
+      res.should.include('A message should be a short, complete sentence.');
     });
   });
 });

--- a/test/uiauto/base.js
+++ b/test/uiauto/base.js
@@ -71,6 +71,7 @@ async function newInstruments (bootstrapFile) {
     simulatorSdkAndDevice = 'iPhone 6 (8.4)';
     withoutDelay = false;
   }
+
   return await instrumentsUtils.quickInstruments({
     app: path.resolve(rootDir, 'test', 'assets', 'UICatalog.app'),
     bootstrap: bootstrapFile,

--- a/uiauto/lib/mechanic-ext/alert-ext.js
+++ b/uiauto/lib/mechanic-ext/alert-ext.js
@@ -27,8 +27,8 @@
         if (text.indexOf('http') === 0 || text === "") {
           text = texts.last().name();
         } else {
-          text = texts[texts.length - 2].name();
-          var subtext = texts.last().name();
+          text = texts[0].name();
+          var subtext = texts[1].name();
           if (subtext !== null) {
             text = text + ' ' + subtext;
           }


### PR DESCRIPTION
Recent `getAlert()` tests return an array with three elements:
```
var alert = getAlert();
alert[0].text(); // ->  title
alert[1].text(); // ->  subtext
alert[2].text(); // ->  null
```

The additional `null` element confused the current logic and `getAlertText()` would only return the subtext, instead of both the title _and_ subtext.