### PR TITLE
Fix background method

### DIFF
--- a/uiauto/lib/mechanic-ext/device-ext.js
+++ b/uiauto/lib/mechanic-ext/device-ext.js
@@ -29,9 +29,60 @@
       return $.target().lockForDuration(seconds);
     }
 
+    // Use while-loop to wait, (i.e. when the app is backgrounded)
+  , wait: function (ms) {
+      var now = Date.now();
+      while (Date.now() - now < ms);
+    }
+
   , background: function (secs) {
       var seconds = parseInt(secs, 10);
-      return $.target().deactivateAppForDuration(seconds);
+      var version = parseInt($.systemVersion.split(".")[0], 10);
+      var bundleId = $.bundleId();
+      var appName = $.mainApp().name();
+      try {
+        if (version >= 9) {
+          $.target().deactivateAppForDuration(seconds);
+        } else {
+          $.backgroundWithRetry(secs);
+        }
+      } catch (ign) {}
+
+      $.wait(1000); // wait for a second so the app is shown
+      if ($.bundleId() === bundleId) {
+        return;
+      }
+
+      var pi = $.mainWindow().pageIndicators()[0];
+      if (!pi.isValid()) {
+        var apps = $.mainWindow().scrollViews()[0].elements().toArray();
+        $.target().tap(apps[apps.length - 2].hitpoint());
+      } else {
+        // if the app is not relaunched, the system doesn't even wait
+        $.wait(secs * 1000);
+        var rt = pi.rect();
+        var pt = {x: rt.origin.x + rt.size.width * 0.7, y: rt.origin.y + rt.size.height * 0.5};
+        var mainScreen = $.mainWindow().scrollViews()[0];
+        while (!mainScreen.buttons().firstWithPredicate("name='" + appName + "' and visible=true").isValid()) {
+          $.target().tap(pt);
+          $.wait(500);
+          if (pi.pageIndex() === pi.pageCount() - 1) {
+            break;
+          }
+        }
+        $.target().tap(mainScreen.buttons()[appName].hitpoint());
+      }
+    }
+
+  , backgroundWithRetry: function (secs) {
+      secs = parseInt(secs, 10);
+      var x = $.target().deactivateAppForDuration(secs);
+      var MAX_RETRY = 5, retry_count = 0;
+      while (!x && retry_count < MAX_RETRY) {
+        x = $.target().deactivateAppForDuration(secs);
+        retry_count += 1;
+      }
+      return x;
     }
 
     // Obtaining Device Property Information like Name, OS ver, Model etc


### PR DESCRIPTION
Fix from @wuhao5 (https://github.com/wuhao5/appium-uiauto/commit/c787e7d6350254a401314bd27abe20d81ad39d00), plus retry code for earlier versions of iOS. This will allow iOS 9.x to background the app, replacing the need to use AppleScript (so it should work on real devices too).