### PR TITLE
Allow an initial geo location to be passed in

### DIFF
--- a/lib/dynamic-bootstrap.js
+++ b/lib/dynamic-bootstrap.js
@@ -28,6 +28,7 @@ function getEnv (opts = {}) {
     autoAcceptAlerts: opts.autoAcceptAlerts,
     autoDismissAlerts: opts.autoDismissAlerts,
     sendKeyStrategy: opts.sendKeyStrategy,
+    initialLocation: opts.initialLocation,
   };
 }
 

--- a/uiauto/bootstrap.js
+++ b/uiauto/bootstrap.js
@@ -1,4 +1,4 @@
-/* globals env, alerts, commands */
+/* globals env, alerts, commands, $ */
 
 /* jshint ignore:start */
 #import "./vendors/mechanic.js"
@@ -19,6 +19,10 @@ var bootstrap;
     } else {
       alerts.configure();
       commands.startProcessing();
+    }
+
+    if (env.initialLocation) {
+      $.target().setLocation(env.initialLocation);
     }
   };
 })();

--- a/uiauto/lib/env.js
+++ b/uiauto/lib/env.js
@@ -12,6 +12,7 @@ var env;
     this.autoAcceptAlerts = dynamicEnv.autoAcceptAlerts;
     this.autoDismissAlerts = dynamicEnv.autoDismissAlerts;
     this.sendKeyStrategy = dynamicEnv.sendKeyStrategy;
+    this.initialLocation = dynamicEnv.initialLocation;
   };
 
 })();


### PR DESCRIPTION
A user can pass in an option `initialLocation` that has `{latitude, longitude}` as its value. If this is there it will be run against the device. The normal disclaimer about location services is still in effect.